### PR TITLE
Add flexibility to `file` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ deploy(opts, files, logger, function(err){
   - `metadata`: {cacheControl: 'public, max-age=31556926'} // metadata for each uploaded file
   - `testRun`: false, // set to true if you just want to check connectivity and see deployment logs. No blobs will be removed or uplaoded.
 - `files`: [] - array of files objects to be deployed
-  - `cwd` - current working directory path
   - `path` - absolute path of file
+  - `cwd` - [deprecated] current working directory path. Now replaced by `base`
+  - `base` - the base directory in which the file is located. The relative path of file to this directory is used as the destination path
+    *Note*: if both `base` and `cwd` are missing, the file will be uploaded to the root of the CDN `folder`.
 - `logger` - logger compatible with console.log(param1, param2...)
 - `cb` - node callback
-
-
 
 ## Grunt and gulp plugins
 See plugins as repositories:
@@ -77,4 +77,3 @@ See plugins as repositories:
 ## TODO, contributions are welcome
 
 - use streams to upload encoded files
-

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ deploy(opts, files, logger, function(err){
 - `files`: [] - array of files objects to be deployed
   - `path` - absolute path of file
   - `cwd` - [deprecated] current working directory path. Now replaced by `base`
-  - `base` - the base directory in which the file is located. The relative path of file to this directory is used as the destination path
+  - `base` - (optional) the base directory in which the file is located. The relative path of file to this directory is used as the destination path  
     *Note*: if both `base` and `cwd` are missing, the file will be uploaded to the root of the CDN `folder`.
+  - `dest` - (optional) if provided, file will be uploaded to this path on CDN. (relative to the `folder`). Useful for cases where you want to upload to a different path or file name.
 - `logger` - logger compatible with console.log(param1, param2...)
 - `cb` - node callback
 

--- a/__tests__/upload-concurrecnt-control-test.js
+++ b/__tests__/upload-concurrecnt-control-test.js
@@ -11,10 +11,10 @@ describe('Azure Deploy Task', function () {
         var azure = require('azure-storage');
         var zlib = require('zlib');
         var files = [
-            {cwd: '/project', path: '/project/dist/file1.js'},
-            {cwd: '/project', path: '/project/dist/file2.js'},
-            {cwd: '/project', path: '/project/dist/file3.js'},
-            {cwd: '/project', path: '/project/dist/file4.js'}
+            {base: '/project', path: '/project/dist/file1.js'},
+            {base: '/project', path: '/project/dist/file2.js'},
+            {base: '/project', path: '/project/dist/file3.js'},
+            {base: '/project', path: '/project/dist/file4.js'}
         ];
         var logger = jest.genMockFunction();
         var cb = jest.genMockFunction();
@@ -62,10 +62,10 @@ describe('Azure Deploy Task', function () {
         var azure = require('azure-storage');
         var zlib = require('zlib');
         var files = [
-            {cwd: '/project', path: '/project/dist/file1.js'},
-            {cwd: '/project', path: '/project/dist/file2.js'},
-            {cwd: '/project', path: '/project/dist/file3.js'},
-            {cwd: '/project', path: '/project/dist/file4.js'}
+            {base: '/project', path: '/project/dist/file1.js'},
+            {base: '/project', path: '/project/dist/file2.js'},
+            {base: '/project', path: '/project/dist/file3.js'},
+            {base: '/project', path: '/project/dist/file4.js'}
         ];
         var logger = jest.genMockFunction();
         var cb = jest.genMockFunction();
@@ -104,10 +104,10 @@ describe('Azure Deploy Task', function () {
         var azure = require('azure-storage');
         var zlib = require('zlib');
         var files = [
-            {cwd: '/project', path: '/project/dist/file1.js'},
-            {cwd: '/project', path: '/project/dist/file2.js'},
-            {cwd: '/project', path: '/project/dist/file3.js'},
-            {cwd: '/project', path: '/project/dist/file4.js'}
+            {base: '/project', path: '/project/dist/file1.js'},
+            {base: '/project', path: '/project/dist/file2.js'},
+            {base: '/project', path: '/project/dist/file3.js'},
+            {base: '/project', path: '/project/dist/file4.js'}
         ];
         var logger = jest.genMockFunction();
         var cb = jest.genMockFunction();
@@ -140,6 +140,61 @@ describe('Azure Deploy Task', function () {
         expect(logger).toBeCalledWith("Uploading", "path/in/cdn/dist/file4.js", "encoding", undefined);
         expect(logger).toBeCalledWith("Uploaded", "path/in/cdn/dist/file4.js", "to", "testContainer");
         expect(cb).toBeCalledWith(undefined);
+    });
+
+    it('should use cwd of a file if base missing and should warn about deprecation', function () {
+      jest.mock('azure-storage');
+      jest.mock('zlib');
+      var deploy = require('../src/deploy-task');
+      var azure = require('azure-storage');
+      var files = [
+          { cwd: '/project', path: '/project/dist/file1.js' },
+      ];
+      var logger = jest.genMockFunction();
+      var cb = jest.genMockFunction();
+      var opts = {
+          containerName: 'testContainer',
+          folder: 'path/in/cdn',
+          deleteExistingBlobs: false
+      };
+      azure.createBlobService().createContainerIfNotExists.mockImplementation(function (param1, param2, callback) {
+          callback();
+      });
+      azure.createBlobService().createBlockBlobFromLocalFile.mockImplementation(function (param1, param2, param3, param4, callback) {
+          callback();
+      });
+      deploy(opts, files, logger, cb);
+      jest.runAllTimers();
+      expect(logger).toBeCalledWith('[WARNING] `cwd` is deprecated. please use `base` in your files');
+      expect(logger).toBeCalledWith("Uploading", "path/in/cdn/dist/file1.js", "encoding", undefined);
+      expect(logger).toBeCalledWith("Uploaded", "path/in/cdn/dist/file1.js", "to", "testContainer");
+    });
+
+    it('should use filename if no base provided', function () {
+      jest.mock('azure-storage');
+      jest.mock('zlib');
+      var deploy = require('../src/deploy-task');
+      var azure = require('azure-storage');
+      var files = [
+          { path: '/project/dist/file1.js' },
+      ];
+      var logger = jest.genMockFunction();
+      var cb = jest.genMockFunction();
+      var opts = {
+          containerName: 'testContainer',
+          folder: 'path/in/cdn',
+          deleteExistingBlobs: false
+      };
+      azure.createBlobService().createContainerIfNotExists.mockImplementation(function (param1, param2, callback) {
+          callback();
+      });
+      azure.createBlobService().createBlockBlobFromLocalFile.mockImplementation(function (param1, param2, param3, param4, callback) {
+          callback();
+      });
+      deploy(opts, files, logger, cb);
+      jest.runAllTimers();
+      expect(logger).toBeCalledWith("Uploading", "path/in/cdn/file1.js", "encoding", undefined);
+      expect(logger).toBeCalledWith("Uploaded", "path/in/cdn/file1.js", "to", "testContainer");
     });
 
 });

--- a/__tests__/upload-concurrecnt-control-test.js
+++ b/__tests__/upload-concurrecnt-control-test.js
@@ -197,4 +197,31 @@ describe('Azure Deploy Task', function () {
       expect(logger).toBeCalledWith("Uploaded", "path/in/cdn/file1.js", "to", "testContainer");
     });
 
+    it('should upload to `dest` if provided', function () {
+      jest.mock('azure-storage');
+      jest.mock('zlib');
+      var deploy = require('../src/deploy-task');
+      var azure = require('azure-storage');
+      var files = [
+          { base: '/project', path: '/project/dist/file1.js', dest: 'path/some-file.js' },
+      ];
+      var logger = jest.genMockFunction();
+      var cb = jest.genMockFunction();
+      var opts = {
+          containerName: 'testContainer',
+          folder: 'path/in/cdn',
+          deleteExistingBlobs: false
+      };
+      azure.createBlobService().createContainerIfNotExists.mockImplementation(function (param1, param2, callback) {
+          callback();
+      });
+      azure.createBlobService().createBlockBlobFromLocalFile.mockImplementation(function (param1, param2, param3, param4, callback) {
+          callback();
+      });
+      deploy(opts, files, logger, cb);
+      jest.runAllTimers();
+      expect(logger).toBeCalledWith("Uploading", "path/in/cdn/path/some-file.js", "encoding", undefined);
+      expect(logger).toBeCalledWith("Uploaded", "path/in/cdn/path/some-file.js", "to", "testContainer");
+    });
+
 });

--- a/src/deploy-task.js
+++ b/src/deploy-task.js
@@ -177,7 +177,12 @@ module.exports = function deploy(opt, files, loggerCallback, cb) {
         return;
     }
     async.eachLimit(files, options.concurrentUploadThreads, function (file, eachCallback) {
-        var relativePath = file.cwd ? path.relative(file.cwd, file.path) : path.basename(file.path);
+        if(file.cwd && !file.base){
+          loggerCallback('[WARNING] `cwd` is deprecated. please use `base` in your files');
+        }
+
+        var dir = file.base || file.cwd;
+        var relativePath = dir ? path.relative(dir, file.path) : path.basename(file.path);
         var destFileName = path.join(options.folder, file.dest || relativePath);
         var sourceFile = file.path;
         var metadata = clone(options.metadata);

--- a/src/deploy-task.js
+++ b/src/deploy-task.js
@@ -177,7 +177,7 @@ module.exports = function deploy(opt, files, loggerCallback, cb) {
         return;
     }
     async.eachLimit(files, options.concurrentUploadThreads, function (file, eachCallback) {
-        var relativePath = file.cwd ? path.relative(file.cwd, file.path) : file.path;
+        var relativePath = file.cwd ? path.relative(file.cwd, file.path) : path.basename(file.path);
         var destFileName = path.join(options.folder, file.dest || relativePath);
         var sourceFile = file.path;
         var metadata = clone(options.metadata);

--- a/src/deploy-task.js
+++ b/src/deploy-task.js
@@ -177,8 +177,8 @@ module.exports = function deploy(opt, files, loggerCallback, cb) {
         return;
     }
     async.eachLimit(files, options.concurrentUploadThreads, function (file, eachCallback) {
-        var relativePath = path.relative(file.cwd, file.path);
-        var destFileName = path.join(options.folder, relativePath);
+        var relativePath = file.cwd ? path.relative(file.cwd, file.path) : file.path;
+        var destFileName = path.join(options.folder, file.dest || relativePath);
         var sourceFile = file.path;
         var metadata = clone(options.metadata);
         metadata.contentType = mime.lookup(sourceFile);

--- a/src/deploy-task.js
+++ b/src/deploy-task.js
@@ -215,4 +215,3 @@ module.exports = function deploy(opt, files, loggerCallback, cb) {
         cb(err);
     });
 };
-


### PR DESCRIPTION
Changes:

- Allow providing `dest` for each so that we can upload a file to a different destination path.
- deprecate `cwd` and use `base` instead.
- Make `base`/`cwd` optional in the sense that if it's missing, use the file name as the destination path.