### PR TITLE
deep clone options

### DIFF
--- a/src/deploy-task.js
+++ b/src/deploy-task.js
@@ -151,7 +151,7 @@ function clone(obj) {
  * @param cb - standard node.js callback. If first parameter is undefined then upload is successful
  ` */
 module.exports = function deploy(opt, files, loggerCallback, cb) {
-    var options = extend({}, {
+    var options = extend(true, {}, {
         serviceOptions: [], // custom arguments to azure.createBlobService
         containerName: null, // container name, required
         containerOptions: {publicAccessLevel: "blob"}, // container options


### PR DESCRIPTION
Hi K!

This PR probably fixes #7 

The [boolean first parameter forces a deep clone](https://github.com/dreamerslab/node.extend#a-note-about-deep-merge-avoiding-pass-by-reference-cloning).