### PR TITLE
Include retry policy filters to protect against blob/network errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 
 /.idea/
+yarn-error.log

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ deploy(opts, files, logger, function(err){
   - `deleteExistingBlobs`: true, // set it to false to skip recursive deleting blobs in folder
   - `concurrentUploadThreads` : 10, // number of concurrent uploads, choose best for your network condition
   - `zip`: false, // true if want to gzip the files before uploading. File will be zipped only if compressed file is smaller than original
+  - `filters`: `[new azure.ExponentialRetryPolicyFilter()]`, // list of filters to apply to blob service.
   - `metadata`: {cacheControl: 'public, max-age=31556926'} // metadata for each uploaded file
   - `testRun`: false, // set to true if you just want to check connectivity and see deployment logs. No blobs will be removed or uplaoded.
 - `files`: [] - array of files objects to be deployed

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ var opts = {
     deleteExistingBlobs: true, // true means recursively deleting anything under folder
     concurrentUploadThreads: 2, // number of concurrent uploads, choose best for your network condition
     zip: true, // gzip files if they become smaller after zipping, content-encoding header will change if file is zipped
+    filters: [new azure.ExponentialRetryPolicyFilter()], 
     metadata: {cacheControl: 'public, max-age=31556926'}, // metadata for each uploaded file
     testRun: false // test run - means no blobs will be actually deleted or uploaded, see log messages for details
 };
@@ -59,7 +60,7 @@ deploy(opts, files, logger, function(err){
   - `deleteExistingBlobs`: true, // set it to false to skip recursive deleting blobs in folder
   - `concurrentUploadThreads` : 10, // number of concurrent uploads, choose best for your network condition
   - `zip`: false, // true if want to gzip the files before uploading. File will be zipped only if compressed file is smaller than original
-  - `filters`: `[new azure.ExponentialRetryPolicyFilter()]`, // list of filters to apply to blob service.
+  - `filters`: `<azure.IFilter>[]`, // list of filters to apply to blob service.
   - `metadata`: {cacheControl: 'public, max-age=31556926'} // metadata for each uploaded file
   - `testRun`: false, // set to true if you just want to check connectivity and see deployment logs. No blobs will be removed or uplaoded.
 - `files`: [] - array of files objects to be deployed

--- a/__mocks__/azure-storage.js
+++ b/__mocks__/azure-storage.js
@@ -12,5 +12,7 @@ module.exports = {
     createBlobService: function () {
         return mocks;
     },
-    ExponentialRetryPolicyFilter: jest.fn().mockImplementation(() => {return jest.fn()})
+    ExponentialRetryPolicyFilter: jest.fn().mockImplementation(() => {return jest.fn()}),
+    LinearRetryPolicyFilter: jest.fn().mockImplementation(() => {return jest.fn()}),
+    RetryPolicyFilter: jest.fn().mockImplementation(() => {return jest.fn()})
 };

--- a/__mocks__/azure-storage.js
+++ b/__mocks__/azure-storage.js
@@ -4,11 +4,13 @@ var mocks = {
     createContainerIfNotExists: jest.fn(),
     listBlobsSegmentedWithPrefix: jest.fn(),
     deleteBlob: jest.fn(),
-    createBlockBlobFromLocalFile: jest.fn()
+    createBlockBlobFromLocalFile: jest.fn(),
+    withFilter: jest.fn(),
 };
 
 module.exports = {
     createBlobService: function () {
         return mocks;
-    }
+    },
+    ExponentialRetryPolicyFilter: jest.fn().mockImplementation(() => {return jest.fn()})
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deploy-azure-cdn",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A package that copies files to Azure CDN. Can be used as gulp task.",
   "main": "index.js",
   "repository": {

--- a/src/deploy-task.js
+++ b/src/deploy-task.js
@@ -158,6 +158,7 @@ module.exports = function deploy(opt, files, loggerCallback, cb) {
         folder: '', // path within container
         deleteExistingBlobs: true, // true means recursively deleting anything under folder
         concurrentUploadThreads: 10, // number of concurrent uploads, choose best for your network condition
+        filters: [new azure.ExponentialRetryPolicyFilter()], // list of filters to apply to blob service.
         zip: false, // gzip files if they become smaller after zipping, content-encoding header will change if file is zipped
         metadata: {cacheControl: 'public, max-age=31556926'}, // metadata for each uploaded file
         testRun: false // test run - means no blobs will be actually deleted or uploaded, see log messages for details
@@ -166,6 +167,10 @@ module.exports = function deploy(opt, files, loggerCallback, cb) {
         return cb("Missing containerName!");
     }
     var blobService = azure.createBlobService.apply(azure, options.serviceOptions);
+
+    if(options.filters && options.filters.length) {
+        options.filters.forEach(blobService.withFilter);
+    }
 
     var createFolderAndClearPromise = createAzureCdnContainer(blobService, options).
         then(function () {

--- a/src/deploy-task.js
+++ b/src/deploy-task.js
@@ -158,7 +158,7 @@ module.exports = function deploy(opt, files, loggerCallback, cb) {
         folder: '', // path within container
         deleteExistingBlobs: true, // true means recursively deleting anything under folder
         concurrentUploadThreads: 10, // number of concurrent uploads, choose best for your network condition
-        filters: [new azure.ExponentialRetryPolicyFilter()], // list of filters to apply to blob service.
+        filters: [], // list of filters to apply to blob service.
         zip: false, // gzip files if they become smaller after zipping, content-encoding header will change if file is zipped
         metadata: {cacheControl: 'public, max-age=31556926'}, // metadata for each uploaded file
         testRun: false // test run - means no blobs will be actually deleted or uploaded, see log messages for details
@@ -220,3 +220,9 @@ module.exports = function deploy(opt, files, loggerCallback, cb) {
         cb(err);
     });
 };
+
+module.exports.filters = {
+    ExponentialRetryPolicyFilter: new azure.ExponentialRetryPolicyFilter(),
+    LinearRetryPolicyFilter : new azure.LinearRetryPolicyFilter(),
+    RetryPolicyFilter : new azure.RetryPolicyFilter()
+}


### PR DESCRIPTION
Currently, any network/trottling error on the blob will cause a deployment to fail. 

This change adds another parameter to options, to allow the passing in of retry filters.
http://azure.github.io/azure-storage-node/common_filters_exponentialretrypolicyfilter.js.html
