### PR TITLE
Fix application of filters to blobService

### DIFF
--- a/src/deploy-task.js
+++ b/src/deploy-task.js
@@ -169,7 +169,9 @@ module.exports = function deploy(opt, files, loggerCallback, cb) {
     var blobService = azure.createBlobService.apply(azure, options.serviceOptions);
 
     if(options.filters && options.filters.length) {
-        options.filters.forEach(blobService.withFilter);
+        options.filters.forEach(function (filter) {
+            blobService = blobService.withFilter(filter);
+        });
     }
 
     var createFolderAndClearPromise = createAzureCdnContainer(blobService, options).


### PR DESCRIPTION
In the current version, the `filters` option has no effect on the behavior of the code.

`StorageServiceClient.prototype.withFilter` returns a new object with the specified filter applied, thus the `blobService` object needs to be reassigned to the result of adding the filter.

See [StorageServiceClient.prototype.withFilter](https://github.com/Azure/azure-storage-node/blob/master/lib/common/services/storageserviceclient.js)